### PR TITLE
RDPIM-4035 - Add support for default input component to call onChange handler with value instead of event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@outsystems/react-select",
-  "version": "2.4.2-os24",
+  "version": "2.4.2-os25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@outsystems/react-select",
-      "version": "2.4.2-os24",
+      "version": "2.4.2-os25",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -138,5 +138,5 @@
   },
   "sideEffects": false,
   "typings": "types/index.d.ts",
-  "version": "2.4.2-os24"
+  "version": "2.4.2-os25"
 }

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -40,18 +40,26 @@ const Input = ({
   isHidden,
   isDisabled,
   theme,
+  onChange,
   selectProps,
   ...props
-}: InputProps) => (
-  <div style={getStyles('input', { theme, ...props })}>
-    <AutosizeInput
-      className={cx(null, { 'input': true }, className)}
-      inputRef={innerRef}
-      inputStyle={inputStyle(isHidden)}
-      disabled={isDisabled}
-      {...props}
-    />
-  </div>
-);
+}: InputProps) => {
+  const onInputChange = (event) => {
+    onChange(event.currentTarget.value);
+  }
+
+  return (
+    <div style={getStyles('input', { theme, ...props })}>
+      <AutosizeInput
+        {...props}
+        className={cx(null, { 'input': true }, className)}
+        inputRef={innerRef}
+        inputStyle={inputStyle(isHidden)}
+        disabled={isDisabled}
+        onChange={onInputChange}
+      />
+    </div>
+  );
+};
 
 export default Input;


### PR DESCRIPTION
This fixes a bug where if you don't pass any input component to the select, the default component would call onChange with an event via param where it is expecting a string.